### PR TITLE
Fix/windows build

### DIFF
--- a/code/windows_platform/build.bat
+++ b/code/windows_platform/build.bat
@@ -33,7 +33,7 @@ cl -WX -W3 %ignored_warnings% %optimizer_flags% -DWINDOWS=1 -DGAME=1 /FeVariosTe
            /link /LIBPATH %sdl_library_path%/lib/x64/SDL2.lib^
     %included_libraries%
 
-copy ..\..\code\windows_platform\resources\SDL2.dll SDL2.dll
+copy ..\..\resources\SDL2.dll SDL2.dll
 copy %resources_path%\game_character.png game_character.png
 copy %resources_path%\grid_surface.png grid_surface.png
 copy %resources_path%\cartoon.obj cartoon.obj

--- a/code/windows_platform/build.bat
+++ b/code/windows_platform/build.bat
@@ -33,7 +33,7 @@ cl -WX -W3 %ignored_warnings% %optimizer_flags% -DWINDOWS=1 -DGAME=1 /FeVariosTe
            /link /LIBPATH %sdl_library_path%/lib/x64/SDL2.lib^
     %included_libraries%
 
-copy ..\..\resources\SDL2.dll SDL2.dll
+copy %resources_path%\SDL2.dll SDL2.dll
 copy %resources_path%\game_character.png game_character.png
 copy %resources_path%\grid_surface.png grid_surface.png
 copy %resources_path%\cartoon.obj cartoon.obj


### PR DESCRIPTION
changed resources path to SDL2.dll because otherwise the SDL2.dll could not be copied to the build\windows folder